### PR TITLE
Refs issue #83

### DIFF
--- a/yandexmapkit-library/doc/ru/yandex/yandexmapkit/overlay/Overlay.html
+++ b/yandexmapkit-library/doc/ru/yandex/yandexmapkit/overlay/Overlay.html
@@ -277,6 +277,14 @@ Overlay.java: The map layer object which controls overlay objects displayed on i
 <BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Shows / hides the object.</TD>
 </TR>
+<TR BGCOLOR="white" CLASS="TableRowColor">
+<TD ALIGN="right" VALIGN="top" WIDTH="1%"><FONT SIZE="-1">
+<CODE>&nbsp;int</CODE></FONT></TD>
+<TD><CODE><B><A HREF="../../../../ru/yandex/yandexmapkit/overlay/Overlay.html#compareTo(java.lang.Object)">compareTo</A></B></CODE>
+
+<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Used to determine z-order of visible elements.</TD>
+</TR>
 </TABLE>
 &nbsp;
 <P>
@@ -362,6 +370,23 @@ public void <B>setVisible</B>(boolean&nbsp;visible)</PRE>
 </DD>
 <DD><DL>
 <DT><B>Parameters:</B><DD><CODE>visible</CODE> - true - show the object on the screen, false - hide</DL>
+</DD>
+</DL>
+<HR>
+
+<A NAME="compareTo(java.lang.Object)"><!-- --></A><H3>
+compareTo</H3>
+<PRE>
+public int <B>compareTo</B>(java.lang.Object&nbsp;object)</PRE>
+<DL>
+<DD>Used to determine z-order of visible elements. Called when visibility of Overlay or OverlayItem changed. For instance, when user touched OverlayItem and Balloon became visible. See also <A HREF="../../../../ru/yandex/yandexmapkit/overlay/Overlay.html#setPriority(byte)"><CODE>setPriority(byte)</CODE></A><DD><DL>
+</DL>
+</DD>
+<DD><DL>
+<DT><B>Parameters:</B><DD><CODE>object</CODE> - the object to be compared</DL>
+</DD>
+<DD><DL>
+<DT><B>Returns:</B><DD>a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object</DL>
 </DD>
 </DL>
 <HR>

--- a/yandexmapkit-library/doc/ru/yandex/yandexmapkit/overlay/OverlayItem.html
+++ b/yandexmapkit-library/doc/ru/yandex/yandexmapkit/overlay/OverlayItem.html
@@ -262,6 +262,14 @@ OverlayItem.java: Renders an overlay object.
 <BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Sets the visibility of the object being rendered.</TD>
 </TR>
+<TR BGCOLOR="white" CLASS="TableRowColor">
+<TD ALIGN="right" VALIGN="top" WIDTH="1%"><FONT SIZE="-1">
+<CODE>&nbsp;int</CODE></FONT></TD>
+<TD><CODE><B><A HREF="../../../../ru/yandex/yandexmapkit/overlay/Overlay.html#compareTo(java.lang.Object)">compareTo</A></B></CODE>
+
+<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Used to determine z-order of visible elements.</TD>
+</TR>
 </TABLE>
 &nbsp;
 <P>
@@ -324,6 +332,23 @@ public void <B>setVisible</B>(boolean&nbsp;visible)</PRE>
 </DD>
 <DD><DL>
 <DT><B>Parameters:</B><DD><CODE>visible</CODE> - true - the object should be visible while it is being rendered, false - hidden</DL>
+</DD>
+</DL>
+<HR>
+
+<A NAME="compareTo(java.lang.Object)"><!-- --></A><H3>
+compareTo</H3>
+<PRE>
+public int <B>compareTo</B>(java.lang.Object&nbsp;object)</PRE>
+<DL>
+<DD>Used to determine z-order of visible elements. Called when visibility of Overlay or OverlayItem changed. For instance, when user touched OverlayItem and Balloon became visible. See also <A HREF="../../../../ru/yandex/yandexmapkit/overlay/OverlayItem.html#setPriority(byte)"><CODE>setPriority(byte)</CODE></A><DD><DL>
+</DL>
+</DD>
+<DD><DL>
+<DT><B>Parameters:</B><DD><CODE>object</CODE> - the object to be compared</DL>
+</DD>
+<DD><DL>
+<DT><B>Returns:</B><DD>a negative integer, zero, or a positive integer as this object is less than, equal to, or greater than the specified object</DL>
 </DD>
 </DL>
 <HR>

--- a/yandexmapkit-sample/src/ru/mapkittest/balloonoverlay/one/ImageBalloonItem.java
+++ b/yandexmapkit-sample/src/ru/mapkittest/balloonoverlay/one/ImageBalloonItem.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 import ru.mapkittest.R;
+import ru.yandex.yandexmapkit.overlay.OverlayItem;
 import ru.yandex.yandexmapkit.overlay.balloon.BalloonItem;
 import ru.yandex.yandexmapkit.overlay.balloon.OnBalloonListener;
 import ru.yandex.yandexmapkit.utils.GeoPoint;
@@ -105,5 +106,19 @@ public class ImageBalloonItem extends BalloonItem implements OnBalloonListener{
     public void onBalloonAnimationEnd(BalloonItem balloonItem) {
         // TODO Auto-generated method stub
 
+    }
+
+    @Override
+    public int compareTo(Object object) {
+        int thisPriority = getPriority();
+        int itemPriority = ((OverlayItem) object).getPriority();
+
+        if (thisPriority < itemPriority) {
+            return -1;
+        } else if (thisPriority == itemPriority) {
+            return 0;
+        } else {
+            return 1;
+        }
     }
 }

--- a/yandexmapkit-sample/src/ru/mapkittest/balloonoverlay/two/ImageBalloonItem.java
+++ b/yandexmapkit-sample/src/ru/mapkittest/balloonoverlay/two/ImageBalloonItem.java
@@ -12,6 +12,7 @@ import android.view.ViewGroup;
 import android.widget.ImageView;
 import android.widget.TextView;
 import ru.mapkittest.R;
+import ru.yandex.yandexmapkit.overlay.OverlayItem;
 import ru.yandex.yandexmapkit.overlay.balloon.BalloonItem;
 import ru.yandex.yandexmapkit.overlay.balloon.OnBalloonListener;
 import ru.yandex.yandexmapkit.utils.GeoPoint;
@@ -75,5 +76,19 @@ public class ImageBalloonItem extends BalloonItem implements OnBalloonListener{
 
     @Override
     public void onBalloonAnimationEnd(BalloonItem balloonItem) {
+    }
+
+    @Override
+    public int compareTo(Object object) {
+        int thisPriority = getPriority();
+        int itemPriority = ((OverlayItem) object).getPriority();
+
+        if (thisPriority < itemPriority) {
+            return -1;
+        } else if (thisPriority == itemPriority) {
+            return 0;
+        } else {
+            return 1;
+        }
     }
 }

--- a/yandexmapkit-sample/src/ru/mapkittest/geocode/OverlayGeoCode.java
+++ b/yandexmapkit-sample/src/ru/mapkittest/geocode/OverlayGeoCode.java
@@ -7,6 +7,7 @@ import ru.yandex.yandexmapkit.MapController;
 import ru.yandex.yandexmapkit.map.GeoCode;
 import ru.yandex.yandexmapkit.map.GeoCodeListener;
 import ru.yandex.yandexmapkit.overlay.Overlay;
+import ru.yandex.yandexmapkit.overlay.OverlayItem;
 import ru.yandex.yandexmapkit.utils.ScreenPoint;
 
 public class OverlayGeoCode extends Overlay implements GeoCodeListener{
@@ -39,4 +40,17 @@ public class OverlayGeoCode extends Overlay implements GeoCodeListener{
         return true;
     }
 
+    @Override
+    public int compareTo(Object object) {
+        int thisPriority = getPriority();
+        int itemPriority = ((OverlayItem) object).getPriority();
+
+        if (thisPriority < itemPriority) {
+            return -1;
+        } else if (thisPriority == itemPriority) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
 }

--- a/yandexmapkit-sample/src/ru/mapkittest/path/OverlayRect.java
+++ b/yandexmapkit-sample/src/ru/mapkittest/path/OverlayRect.java
@@ -62,4 +62,17 @@ public class OverlayRect extends Overlay {
         return draw;
     }
 
+    @Override
+    public int compareTo(Object object) {
+        int thisPriority = getPriority();
+        int itemPriority = ((OverlayItem) object).getPriority();
+
+        if (thisPriority < itemPriority) {
+            return -1;
+        } else if (thisPriority == itemPriority) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
 }

--- a/yandexmapkit-sample/src/ru/mapkittest/path/OverlayRectItem.java
+++ b/yandexmapkit-sample/src/ru/mapkittest/path/OverlayRectItem.java
@@ -16,5 +16,18 @@ public class OverlayRectItem extends OverlayItem {
         super(geoPoint, drawable);
         // TODO Auto-generated constructor stub
     }
-    
+
+    @Override
+    public int compareTo(Object object) {
+        int thisPriority = getPriority();
+        int itemPriority = ((OverlayItem) object).getPriority();
+
+        if (thisPriority < itemPriority) {
+            return -1;
+        } else if (thisPriority == itemPriority) {
+            return 0;
+        } else {
+            return 1;
+        }
+    }
 }


### PR DESCRIPTION
Как выяснилось при тапе по `OverlayItem`'у при показе `Balloon`'а большую роль играет метод, наследованный от `java.lang.Comparable` `compareTo`, который в примерах не реализован. Он определяет последовательность в которой будут отрисованы видимые на экране элементы, `setPriority` в данном случае роли не играет.

Возможно имеет смысл реализовать `compareTo` по умолчанию внутри `Overlay` и `OverlayItem`, подобным образом, чтобы при использовании дефолтного приоритета получить ожидаемое поведение:

```
    @Override
    public int compareTo(Object object) {
        int thisPriority = getPriority();
        int itemPriority = ((OverlayItem) object).getPriority();

        if (thisPriority < itemPriority) {
            return -1;
        } else if (thisPriority == itemPriority) {
            return 0;
        } else {
            return 1;
        }
    } 
```

А так же исключить однотипную реализацию данного метода из кода примеров
